### PR TITLE
Users are unable handle Salesforce errors using custom sequences.

### DIFF
--- a/connector/src/main/resources/salesforce/init.xml
+++ b/connector/src/main/resources/salesforce/init.xml
@@ -16,7 +16,7 @@
  ~  specific language governing permissions and limitations
  ~  under the License.
 -->
-<template name="init" onError="fault"
+<template name="init"
           xmlns="http://ws.apache.org/ns/synapse">
     <parameter name="username" description="The username for the salesforce account"/>
     <parameter name="password"


### PR DESCRIPTION
In the init sequence FORCE_ERROR_ON_SOAP_FAULT property is set which will trigger the fault sequence if a Soap Fault occurs. At the same time in the init sequence template an onError sequence is set and the the error will always go to the default fault sequence. The user should be able to handle the error.