### PR TITLE
Add a session cache to SF connector

### DIFF
--- a/connector/src/main/java/org/wso2/carbon/connector/salesforce/SalesforceUtil.java
+++ b/connector/src/main/java/org/wso2/carbon/connector/salesforce/SalesforceUtil.java
@@ -49,6 +49,13 @@ public final class SalesforceUtil {
     public static final String SALESFORCE_LOGIN_FORCE = "forceLogin";
     public static final String SALESFORCE_LOGIN_DONE = "salesforce.login.done";
     public static final String SALESFORCE_CRUD_PREFIX = "salesforce.crud.";
+    public static final String SALESFORCE_USER_NAME = "username";
+    public static final String SALESFORCE_USER_PASSWORD = "password";
+    public static final String SALESFORCE_LOGIN_URL = "loginUrl";
+    public static final String SALESFORCE_SERVICE_URL = "salesforce.serviceUrl";
+    public static final String SALESFORCE_LOGIN_SESSION_ID = "salesforce.sessionId";
+    public static final String SALESFORCE_LOGIN_ADD_TO_CACHE = "salesforce.login.addToCache";
+    public static final String SALESFORCE_LOGIN_SESSION_VALIDITY = "salesforce.sessionvalidity";
 
     public static void addSobjects(String strOperation, String strParamName, MessageContext synCtx,
                             SynapseLog synLog, String strExternalId) {

--- a/connector/src/main/java/org/wso2/carbon/connector/salesforce/SessionInfo.java
+++ b/connector/src/main/java/org/wso2/carbon/connector/salesforce/SessionInfo.java
@@ -1,0 +1,44 @@
+package org.wso2.carbon.connector.salesforce;
+
+/**
+ * Stores salesforce login data
+ */
+public class SessionInfo {
+
+    String sessionId;
+    String serviceUrl;
+    int sessionCreatedTimeInSeconds;
+    int sessionValidityInSeconds;
+
+    public int getSessionCreatedTimeInSeconds() {
+        return sessionCreatedTimeInSeconds;
+    }
+
+    public void setSessionCreatedTimeInSeconds(int sessionCreatedTimeInSeconds) {
+        this.sessionCreatedTimeInSeconds = sessionCreatedTimeInSeconds;
+    }
+
+    public int getSessionValidityInSeconds() {
+        return sessionValidityInSeconds;
+    }
+
+    public void setSessionValidityInSeconds(int sessionValidityInSeconds) {
+        this.sessionValidityInSeconds = sessionValidityInSeconds;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getServiceUrl() {
+        return serviceUrl;
+    }
+
+    public void setServiceUrl(String serviceUrl) {
+        this.serviceUrl = serviceUrl;
+    }
+}

--- a/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
+++ b/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
@@ -72,7 +72,6 @@ public class SetupLoginParams extends AbstractConnector {
             // If force login is set we don't do anything
             if (strValue != null || "true".equals(strValue)) {
                 // Setting Transport Headers
-                System.out.println("Initializing the Session");
                 axis2smc.getAxis2MessageContext().getOperationContext()
                         .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "false");
             } else {

--- a/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
+++ b/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
@@ -79,7 +79,6 @@ public class SetupLoginParams extends AbstractConnector {
                         axis2smc.getAxis2MessageContext().getOperationContext()
                                 .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "true");
                     } else {
-                        System.out.println("Initializing the Session");
                         axis2smc.getAxis2MessageContext().getOperationContext()
                                 .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "false");
                     }

--- a/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
+++ b/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
@@ -46,18 +46,24 @@ public class SetupLoginParams extends AbstractConnector {
             if ("true".equals(axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_LOGIN_ADD_TO_CACHE))) {
 
                 String sessionId = (String) axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_ID);
-                int sessionValidityInSeconds = Integer.parseInt((String) axis2smc.getAxis2MessageContext().getOperationContext()
-                        .getProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_VALIDITY));
-                String serviceUrl = (String) axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_SERVICE_URL);
+                String sessionValidity = (String) axis2smc.getAxis2MessageContext().getOperationContext()
+                        .getProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_VALIDITY);
 
-                SessionInfo sessionInfo = new SessionInfo();
-                sessionInfo.setSessionId(sessionId);
-                sessionInfo.setServiceUrl(serviceUrl);
-                sessionInfo.setSessionValidityInSeconds(sessionValidityInSeconds);
-                sessionInfo.setSessionCreatedTimeInSeconds((int) (System.currentTimeMillis() / 1000));
+                // If we can't figure out the session validity no point in adding to the session store.
+                if (sessionValidity != null && !sessionValidity.isEmpty()){
+                    int sessionValidityInSeconds = Integer.parseInt((String) axis2smc.getAxis2MessageContext().getOperationContext()
+                            .getProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_VALIDITY));
+                    String serviceUrl = (String) axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_SERVICE_URL);
 
-                cacheMap.put(getSfLoginHash(messageContext), sessionInfo);
-                return;
+                    SessionInfo sessionInfo = new SessionInfo();
+                    sessionInfo.setSessionId(sessionId);
+                    sessionInfo.setServiceUrl(serviceUrl);
+                    sessionInfo.setSessionValidityInSeconds(sessionValidityInSeconds);
+                    sessionInfo.setSessionCreatedTimeInSeconds((int) (System.currentTimeMillis() / 1000));
+
+                    cacheMap.put(getSfLoginHash(messageContext), sessionInfo);
+                    return;
+                }
             }
 
             // Set the force login

--- a/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
+++ b/connector/src/main/java/org/wso2/carbon/connector/salesforce/SetupLoginParams.java
@@ -19,23 +19,90 @@
 package org.wso2.carbon.connector.salesforce;
 
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseException;
+import org.apache.synapse.SynapseLog;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.util.ConnectorUtils;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class SetupLoginParams extends AbstractConnector {
 
-    public void connect(MessageContext messageContext) {
-        // Set the force login
-        String strValue =
-                (String) ConnectorUtils.lookupTemplateParamater(messageContext,
-                        SalesforceUtil.SALESFORCE_LOGIN_FORCE);
-        if (strValue != null || "true".equals(strValue)) {
-            // Setting Transport Headers
+    // Using a simple Map since there is no possibility of cache growth.
+    // Cache key is LoginURL + UserName + Password
+    private static Map<Integer, SessionInfo> cacheMap = new ConcurrentHashMap<>();
+    private static final int sessionCheckBufferInSeconds = 120;
+
+    public void connect(MessageContext messageContext) throws SynapseException {
+
+        SynapseLog synLog = getLog(messageContext);
+
+        try {
             Axis2MessageContext axis2smc = (Axis2MessageContext) messageContext;
-            axis2smc.getAxis2MessageContext().getOperationContext()
-                    .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "false");
+
+            // Add the session info to the cache map
+            if ("true".equals(axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_LOGIN_ADD_TO_CACHE))) {
+
+                String sessionId = (String) axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_ID);
+                int sessionValidityInSeconds = Integer.parseInt((String) axis2smc.getAxis2MessageContext().getOperationContext()
+                        .getProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_VALIDITY));
+                String serviceUrl = (String) axis2smc.getAxis2MessageContext().getOperationContext().getProperty(SalesforceUtil.SALESFORCE_SERVICE_URL);
+
+                SessionInfo sessionInfo = new SessionInfo();
+                sessionInfo.setSessionId(sessionId);
+                sessionInfo.setServiceUrl(serviceUrl);
+                sessionInfo.setSessionValidityInSeconds(sessionValidityInSeconds);
+                sessionInfo.setSessionCreatedTimeInSeconds((int) (System.currentTimeMillis() / 1000));
+
+                cacheMap.put(getSfLoginHash(messageContext), sessionInfo);
+                return;
+            }
+
+            // Set the force login
+            String strValue = (String) ConnectorUtils.lookupTemplateParamater(messageContext,
+                    SalesforceUtil.SALESFORCE_LOGIN_FORCE);
+            // If force login is set we don't do anything
+            if (strValue != null || "true".equals(strValue)) {
+                // Setting Transport Headers
+                System.out.println("Initializing the Session");
+                axis2smc.getAxis2MessageContext().getOperationContext()
+                        .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "false");
+            } else {
+                synchronized (this) {
+                    int hash = getSfLoginHash(messageContext);
+                    SessionInfo sessionInfo = cacheMap.get(hash);
+                    if (sessionInfo != null && isSessionValid(sessionInfo)) {
+                        axis2smc.getAxis2MessageContext().getOperationContext().setProperty(SalesforceUtil.SALESFORCE_LOGIN_SESSION_ID, sessionInfo.sessionId);
+                        axis2smc.getAxis2MessageContext().getOperationContext().setProperty(SalesforceUtil.SALESFORCE_SERVICE_URL, sessionInfo.getServiceUrl());
+                        axis2smc.getAxis2MessageContext().getOperationContext()
+                                .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "true");
+                    } else {
+                        System.out.println("Initializing the Session");
+                        axis2smc.getAxis2MessageContext().getOperationContext()
+                                .setProperty(SalesforceUtil.SALESFORCE_LOGIN_DONE, "false");
+                    }
+                }
+            }
+        } catch (Exception e) {
+            synLog.error("Error occurred while setting logging params in SF connector " + e.getMessage());
+            throw new SynapseException("Error occurred while setting logging params in SF connector " + e.getMessage());
         }
     }
 
+    private int getSfLoginHash(MessageContext messageContext) {
+        String username = (String) ConnectorUtils.lookupTemplateParamater(messageContext, SalesforceUtil.SALESFORCE_USER_NAME);
+        String password = (String) ConnectorUtils.lookupTemplateParamater(messageContext, SalesforceUtil.SALESFORCE_USER_PASSWORD);
+        String loginUrl = (String) ConnectorUtils.lookupTemplateParamater(messageContext, SalesforceUtil.SALESFORCE_LOGIN_URL);
+        int hash = (loginUrl + username + password).hashCode();
+        return hash;
+    }
+
+    private boolean isSessionValid(SessionInfo sessionInfo) {
+        if ((sessionInfo.getSessionValidityInSeconds() - sessionCheckBufferInSeconds) < (System.currentTimeMillis() / 1000) - sessionInfo.getSessionCreatedTimeInSeconds()) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/connector/src/main/resources/salesforce/init.xml
+++ b/connector/src/main/resources/salesforce/init.xml
@@ -25,9 +25,6 @@
     <parameter name="forceLogin" description="The forceLogin parameter"/>
     <parameter name="blocking"
                description="The blocking parameter is helping connector performs the blocking invocations to Salesforce"/>
-    <log level="custom">
-        <property name="URL ====" expression="$ctx:loginUrl"/>
-    </log>
     <sequence>
         <class name="org.wso2.carbon.connector.salesforce.SetupLoginParams"/>
         <filter xpath="get-property('operation','salesforce.login.done') = 'true'">

--- a/connector/src/main/resources/salesforce/init.xml
+++ b/connector/src/main/resources/salesforce/init.xml
@@ -30,7 +30,7 @@
         <filter xpath="get-property('operation','salesforce.login.done') = 'true'">
             <then>
                 <log level="custom">
-                    <property name="Connection" value="Already login to Salesforce ....."/>
+                    <property name="Connection" value="Already logged into Salesforce ....."/>
                 </log>
             </then>
             <else>
@@ -124,6 +124,7 @@
                 <property name="salesforce.login.addToCache" scope="operation"
                           type="STRING" value="true"/>
                 <class name="org.wso2.carbon.connector.salesforce.SetupLoginParams"/>
+                <property name="salesforce.login.addToCache" scope="operation" action="remove"/>
                 <enrich>
                     <source clone="true" type="body"/>
                     <target property="SALESFORCE_LOGIN_RESPONSE" type="property"/>

--- a/connector/src/main/resources/salesforce/init.xml
+++ b/connector/src/main/resources/salesforce/init.xml
@@ -25,11 +25,16 @@
     <parameter name="forceLogin" description="The forceLogin parameter"/>
     <parameter name="blocking"
                description="The blocking parameter is helping connector performs the blocking invocations to Salesforce"/>
+    <log level="custom">
+        <property name="URL ====" expression="$ctx:loginUrl"/>
+    </log>
     <sequence>
         <class name="org.wso2.carbon.connector.salesforce.SetupLoginParams"/>
         <filter xpath="get-property('operation','salesforce.login.done') = 'true'">
             <then>
-                <property name="Connection" value="Already login to Salesforce ....."/>
+                <log level="custom">
+                    <property name="Connection" value="Already login to Salesforce ....."/>
+                </log>
             </then>
             <else>
                 <enrich>
@@ -114,8 +119,14 @@
                 <property expression="//ns:loginResponse/ns:result/ns:serverUrl/text()"
                           name="salesforce.serviceUrl" scope="operation" type="STRING"
                           xmlns:ns="urn:partner.soap.sforce.com"/>
+                <property expression="//ns:loginResponse/ns:result/ns:userInfo/ns:sessionSecondsValid/text()"
+                          name="salesforce.sessionvalidity" scope="operation" type="STRING"
+                          xmlns:ns="urn:partner.soap.sforce.com"/>
                 <property name="salesforce.login.done" scope="operation"
                           type="STRING" value="true"/>
+                <property name="salesforce.login.addToCache" scope="operation"
+                          type="STRING" value="true"/>
+                <class name="org.wso2.carbon.connector.salesforce.SetupLoginParams"/>
                 <enrich>
                     <source clone="true" type="body"/>
                     <target property="SALESFORCE_LOGIN_RESPONSE" type="property"/>


### PR DESCRIPTION
## Purpose

Currently, if you are using the SF connector it will always initiate a login request to SF per request. (If you are calling SF connector multiple times in the same integration it reuses the session). Salesforce has throttling limits when it comes to the number login requests it accepts during a defined time window. So this can cause issues when dealing with high loads. 

This PR introduces a new session store to manage active sessions and to retrieve session data accordingly. The session is identified with the following hash key.

```
Hash(loginUrl + username + password)
```

